### PR TITLE
Correct information about where the draft name goes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ hyphen. The initial version of an I-D must be `00`, and subsequent updates must
 increment the version number by one.
 
 If the I-D is submitted as XML (which is highly recommended), the name and
-version of the document will be declared in the appropriate ["name" and
-"version" attributes](https://rfc-editor.org/info/rfc7991), and the filename
-submitted must be of the form `name-version.xml`.
+version of the document will be declared in a ["seriesInfo"
+element](https://www.rfc-editor.org/rfc/rfc7991.html#section-2.47). The filename
+submitted must have a `.xml` extension.
 
 If the I-D is submitted as plain text (which is not recommended), the name and
 version will appear on the document's first page, and the filename submitted
-must be of the form `name-version.txt`.
+must must have a `.txt` extension.
 
 Convention dictates that an individual submission seeking adoption by a
 working group will include the working group's acronym just after the


### PR DESCRIPTION
I couldn't find a "version" attribute in RFC 7991, other than the one
that always includes a value of "3".  The name does in a `<seriesInfo>`
element.  I tweaked the language to match and simplified a little.