### PR TITLE
Explain -bis names. Driven by tools-discuss thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ I-D named `draft-ietf-wgname-specific-subject` and submit it as
 this new I-D will always be `00`, no matter how many versions of the
 individual draft were posted before adoption.
 
+In addtion, [The Tao of the IETF](https://www.ietf.org/about/participate/tao/)
+(which is well worth reading!) notes that:
+> There are some informal rules for Internet-Draft naming that have
+  evolved over the years. Internet-Drafts that revise existing RFCs
+  often have draft names with "bis" in them, meaning "again" or "twice";
+  for example, a draft might be called "draft-someone-rfc2345bis-00.txt".
+
 ## The Submission Process
 
 Internet-Draft submissions are made using the [IETF Datatracker's submission


### PR DESCRIPTION
There have been some discussions that it is unclear what 'bis' means in a draft name, and that this is documented in the Tao (thread: 'The Tao explains "bis" in HTTP"bis"' - https://mailarchive.ietf.org/arch/msg/tools-discuss/GqIr5d6Z4GgU32JX_99aV0v_yeI

This seemed like a really useful addition. I also make a call-out to the Tao - if someone is new to writing drafts, it seems like an especially useful doc for them to read!.